### PR TITLE
Add Xdebug configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM digirati/omeka-s:7.0.18-fpm
+RUN yes | pecl install xdebug
 
 RUN composer require kokspflanze/zfc-twig:2.*
-
 COPY ./config/application.config.php  /var/www/html/application/config/application.config.php
-
 COPY ./config/php.ini /usr/local/etc/php/php.ini
+
+# Find the containers gateway (host address) and assign it to xdebug.remote_host
+RUN ip route show 0.0.0.0/0 | grep -Eo 'via \S+' | awk "{ print \"xdebug.remote_host=\" \$2 }" | \
+	tee -a /usr/local/etc/php/php.ini

--- a/config/php.ini
+++ b/config/php.ini
@@ -1,2 +1,5 @@
 log_errors = On
 error_log = /dev/stderr
+zend_extension=xdebug.so
+xdebug.remote_enable=on
+xdebug.remote_autostart=off

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@
       container_name: omeka_fast_web
       # image: digirati/omeka-s:7.0.18-fpm
       environment:
+        - PHP_IDE_CONFIG=serverName=omeka-workspace
         - OMEKA__DATABASE_HOST=omeka_fast_mysql
         - OMEKA__DATABASE_NAME=omeka_s
         - OMEKA__DATABASE_USER=omeka_s
@@ -29,6 +30,7 @@
         - mysql
       build:
         context: .
+        dockerfile: Dockerfile
       volumes:
         - ./modules:/var/www/html/modules
         - ./themes:/var/www/html/themes


### PR DESCRIPTION
Enables Xdebug in the PHP configuration and remote debugging.  Debugging is not
started automatically, so to initiate debugging the correct PHP_IDE_KEY will
need to be set up correctly.